### PR TITLE
Update micropub.php

### DIFF
--- a/www/micropub.php
+++ b/www/micropub.php
@@ -154,7 +154,18 @@ if ($_SERVER['REQUEST_METHOD'] == 'GET') {
     } else if ($_GET['q'] === 'config') {
         header('HTTP/1.0 200 OK');
         header('Content-Type: application/json');
-        echo '{}';
+        echo json_encode([
+            'post-types' => [
+                [
+                    'type' => 'reply',
+                    'name' => 'Reply',
+                ],
+                [
+                    'type' => 'like',
+                    'name' => 'Like',
+                ],
+            ]
+        ]);
         exit();
     } else if ($_GET['q'] === 'syndicate-to') {
         header('HTTP/1.0 200 OK');


### PR DESCRIPTION
Add `post-types` to the config query response.

This is specifically for the [Omnibear](https://omnibear.com/) Micropub extension. @aciccarello is working on updating it and would like to only show the post-type icons based on what the server supports (e.g. no "New Note" button).

Closes #12